### PR TITLE
Outlier Selection dialog button and handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 *SOR (statistical Outlier Removal) for floater removal   - added 4/10/25
 *SOR Dialog Text layout adjustment 4/10/25
-
+*SOR Select outliers added
 -------------------------------------------------------------------------
 
 [(https://img.shields.io/github/v/release/playcanvas/supersplat)](https://github.com/playcanvas/supersplat/releases)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 *SOR (statistical Outlier Removal) for floater removal   - added 4/10/25
 *SOR Dialog Text layout adjustment 4/10/25
-*SOR Select outliers added
+*SOR Select outliers added 4/10/25
 -------------------------------------------------------------------------
 
 [(https://img.shields.io/github/v/release/playcanvas/supersplat)](https://github.com/playcanvas/supersplat/releases)

--- a/src/sor-events.ts
+++ b/src/sor-events.ts
@@ -276,6 +276,63 @@ const registerSOREvents = (events: Events, editHistory: EditHistory, scene: Scen
         // Previews are automatically cleared when splats are destroyed
     });
     
+    // Select SOR outliers (no deletion, just set current selection to outliers)
+    events.on('sor.selectOutliers', async (options: SORCleanupOptions) => {
+        const selection = events.invoke('selection') as Splat;
+        if (!selection) {
+            await events.invoke('showPopup', {
+                type: 'error',
+                header: 'SOR Select Error',
+                message: 'No splat selected. Please select a splat to select SOR outliers.'
+            });
+            return;
+        }
+
+        try {
+            // Clear any preview state and restore colors
+            if (originalLockedColor !== null) {
+                events.fire('setLockedClr', originalLockedColor);
+                originalLockedColor = null;
+            }
+            SORCleanup.clearPreview(selection);
+
+            const result = SORCleanup.identifyOutliers(selection, options);
+            const outlierSet = new Set(result.outlierIndices);
+            const filter = (i: number) => outlierSet.has(i);
+
+            // Apply selection
+            events.fire('edit.add', new SelectOp(selection, 'set', filter));
+
+            await events.invoke('showPopup', {
+                type: 'success',
+                header: 'SOR Select Outliers',
+                message: `Selected ${result.totalOutliers.toLocaleString()} outliers out of ${result.totalProcessed.toLocaleString()} processed points.`
+            });
+
+            // Move popup bottom-right (SOR specific)
+            setTimeout(() => {
+                const popupDialog = document.getElementById('popup-dialog');
+                const popupHeader = document.getElementById('popup-header');
+                if (popupDialog && popupHeader && popupHeader.textContent?.includes('SOR')) {
+                    popupDialog.style.position = 'fixed';
+                    popupDialog.style.bottom = '20px';
+                    popupDialog.style.right = '20px';
+                    popupDialog.style.top = 'auto';
+                    popupDialog.style.left = 'auto';
+                    popupDialog.style.transform = 'none';
+                    popupDialog.style.maxWidth = '400px';
+                    popupDialog.setAttribute('data-sor-popup', 'true');
+                }
+            }, 10);
+        } catch (error: any) {
+            await events.invoke('showPopup', {
+                type: 'error',
+                header: 'SOR Select Error',
+                message: `Failed to select SOR outliers: ${error.message || error}`
+            });
+        }
+    });
+
     // Separate SOR outliers into a new splat
     events.on('sor.separate', async (options: SORCleanupOptions) => {
         const selection = events.invoke('selection') as Splat;

--- a/src/ui/css/sor-cleanup.css
+++ b/src/ui/css/sor-cleanup.css
@@ -117,6 +117,7 @@
 
 /* Provide a bit more room for longer labels */
 .sor-cleanup-button.apply { min-width: 140px; }
+.sor-cleanup-button.select-outliers { min-width: 150px; }
 .sor-cleanup-button.separate { min-width: 160px; }
 
 .sor-cleanup-button.cancel,

--- a/src/ui/sor-cleanup-dialog.ts
+++ b/src/ui/sor-cleanup-dialog.ts
@@ -261,6 +261,13 @@ class SORCleanupDialog extends Container {
             enabled: true
         });
 
+        // New: Select Outliers (does not delete – just selects the outlier set)
+        const selectButton = new Button({
+            class: ['sor-cleanup-button', 'select-outliers'],
+            text: 'Select Outliers',
+            enabled: true
+        });
+
         const separateButton = new Button({
             class: ['sor-cleanup-button', 'separate'],
             text: 'Separate Outliers',
@@ -270,11 +277,12 @@ class SORCleanupDialog extends Container {
         buttonContainer.append(cancelButton);
         buttonContainer.append(previewButton);
         buttonContainer.append(applyButton);
+        buttonContainer.append(selectButton);
         buttonContainer.append(separateButton);
         
         // Style buttons with proper white text and hover effects
         setTimeout(() => {
-            [cancelButton, previewButton, applyButton, separateButton].forEach(button => {
+            [cancelButton, previewButton, applyButton, selectButton, separateButton].forEach(button => {
                 if (button.dom) {
                     button.dom.style.color = 'white';
                     button.dom.style.backgroundColor = '#505050';
@@ -332,6 +340,17 @@ class SORCleanupDialog extends Container {
                     previewButton.dom.style.backgroundColor = '#cc5500';
                 });
             }
+
+            // Special styling for select outliers button (teal)
+            if (selectButton.dom) {
+                selectButton.dom.style.backgroundColor = '#00a3b4';
+                selectButton.dom.addEventListener('mouseenter', () => {
+                    selectButton.dom.style.backgroundColor = '#008c99';
+                });
+                selectButton.dom.addEventListener('mouseleave', () => {
+                    selectButton.dom.style.backgroundColor = '#00a3b4';
+                });
+            }
             
             // Special styling for separate button
             if (separateButton.dom) {
@@ -379,6 +398,10 @@ class SORCleanupDialog extends Container {
 
         separateButton.on('click', () => {
             this.separateOutliers();
+        });
+
+        selectButton.on('click', () => {
+            this.selectOutliers();
         });
 
         // Update mode selection based on current selection
@@ -453,6 +476,12 @@ class SORCleanupDialog extends Container {
     private separateOutliers() {
         const options = this.getOptions();
         this.events.fire('sor.separate', options);
+        this.hide();
+    }
+
+    private selectOutliers() {
+        const options = this.getOptions();
+        this.events.fire('sor.selectOutliers', options);
         this.hide();
     }
 }


### PR DESCRIPTION
What’s new
•  New button in the SOR dialog: “Select Outliers”
◦  Behavior: computes outliers using the current SOR parameters and sets the selection to exactly those outliers; it does not delete or separate them.
◦  UI: teal styling, centered text, wraps with the other buttons if needed.
•  New event and logic
◦  Event: sor.selectOutliers
◦  Implementation: identifies outlier indices via SOR, clears any preview, restores colors, and uses SelectOp with op='set' to select those indices. Shows a confirmation popup.

Files changed
•  src/ui/sor-cleanup-dialog.ts
◦  Added the “Select Outliers” button and click handler that fires sor.selectOutliers.
◦  Kept existing buttons and centering tweaks.
•  src/ui/css/sor-cleanup.css
◦  Added a min-width for the new select-outliers button.
◦  Existing wrapping/centering rules remain.
•  src/sor-events.ts
◦  Added handler for sor.selectOutliers (selection only).
◦  No changes to sor.apply and sor.separate logic.
